### PR TITLE
Compatibility fixes for 'html-webpack-plugin' v4.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const childCompiler = require('./lib/compiler.js')
 const assert = require('assert')
 const fs = require('fs')
 const path = require('path')
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const DEFAULT_OPTIONS = {
   emitStats: false,
@@ -106,13 +107,14 @@ class AppManifestWebpackPlugin {
   }
 
   hooksHandler(compilation) {
-    if (!compilation.hooks.htmlWebpackPluginAfterHtmlProcessing && this.options.inject) {
+    const beforeEmit = compilation.hooks.htmlWebpackPluginAfterHtmlProcessing || HtmlWebpackPlugin.getHooks(compilation).beforeEmit;
+    if (!beforeEmit && this.options.inject) {
       const message = `compilation.hooks.htmlWebpackPluginAfterHtmlProcessing is lost.
        Please make sure you have installed html-webpack-plugin and put it before ${PLUGIN_NAME}`
       throw new Error(message)
     }
 
-    compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tapAsync(
+    beforeEmit.tapAsync(
       PLUGIN_NAME,
       (htmlPluginData, cb) => this.htmlProccessingFn(htmlPluginData, cb),
     )


### PR DESCRIPTION
Allow this plug-in to be used with html-webpack-plugin v4.0.0 alpha. See also #5.